### PR TITLE
add grpc build script

### DIFF
--- a/Source/build_grpc.bash
+++ b/Source/build_grpc.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+mkdir build
+BUILD_DIR=build
+
+cd ${BUILD_DIR}
+git clone https://github.com/KyoheiG3/grpc-swift.git
+cd grpc-swift
+make
+
+xcodebuild -target BoringSSL -target gRPC -target Czlib -target CgRPC -target SwiftProtobuf -target SwiftProtobufPluginLibrary -configuration Release -sdk iphoneos


### PR DESCRIPTION
Not completely finished, but at least it builds the frameworks in `build/grpc-swift/build`.