### PR TITLE
Fixed crash when trying to force cast Swift.String as Swift.Error

### DIFF
--- a/Source/Dronecode-SDK-Swift/Dronecode-SDK-Swift/Action.swift
+++ b/Source/Dronecode-SDK-Swift/Dronecode-SDK-Swift/Action.swift
@@ -11,6 +11,10 @@ import Foundation
 import gRPC
 import RxSwift
 
+
+extension String: Error {
+}
+
 public class Action {
     let service = Dronecore_Rpc_Action_ActionServiceServiceClient(address: "localhost:50051", secure: false)
     
@@ -33,7 +37,7 @@ public class Action {
                     completable(.completed)
                     return Disposables.create {}
                 } else {
-                    completable(.error("Cannot arm: \(armResponse.actionResult.result)" as! Error))
+                    completable(.error("Cannot arm: \(armResponse.actionResult.result)"))
                     return Disposables.create {}
                 }
             } catch {
@@ -53,7 +57,7 @@ public class Action {
                     completable(.completed)
                     return Disposables.create {}
                 } else {
-                    completable(.error("Cannot takeoff: \(takeoffResponse.actionResult.result)" as! Error))
+                    completable(.error("Cannot takeoff: \(takeoffResponse.actionResult.result)"))
                     return Disposables.create {}
                 }
             } catch {
@@ -73,7 +77,7 @@ public class Action {
                     completable(.completed)
                     return Disposables.create {}
                 } else {
-                    completable(.error("Cannot land: \(landResponse.actionResult.result)" as! Error))
+                    completable(.error("Cannot land: \(landResponse.actionResult.result)"))
                     return Disposables.create {}
                 }
             } catch {


### PR DESCRIPTION
I have added conformance of Swift.String type to Swift.Error type. It will allow using strings as errors.

It is a temporary solution for the crash. In future, it would be great to implement some custom DroneCore's type for errors that will have:
- unique code (Int value). It will help to localize/customize the issue message
- description (string) that will help to understand the issue 
- solution if it's available (string)